### PR TITLE
CCD-2119: Address CVE-2021-42340

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,8 +205,8 @@ dependencies {
   compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.14.1'
   compile group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.14.1'
 
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.50'
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.0.7'
+  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.54'
+  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.0.12'
 
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   compile group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,4 +15,8 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
 	</suppress>
+  <suppress until="2021-11-25">
+    <notes>Suppress CVE affecting Tomcat temporarily until it can be addressed</notes>
+    <cve>CVE-2021-42340</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,8 +15,4 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
 	</suppress>
-  <suppress until="2021-11-25">
-    <notes>Suppress CVE affecting Tomcat temporarily until it can be addressed</notes>
-    <cve>CVE-2021-42340</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2119 (https://tools.hmcts.net/jira/browse/CCD-2119)


### Change description ###
Updated dependencies section of build.gradle.  Set version of tomcat-embed-core to 9.0.54 and tomcat-embed-websocket to 10.0.12 to resolve CVE-2021-42340.
Removed suppression of CVE-2021-42340 from suppressions.xml.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
