### PR TITLE
CCD-2140: Address CVE-2021-22096

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,6 +187,8 @@ ext.libraries = [
   ]
 ]
 
+ext['spring-framework.version'] = '5.3.12'
+
 dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -9,7 +9,7 @@
     <cpe>cpe:/a:pivotal_software:spring_security</cpe>
     <cve>CVE-2018-1258</cve>
   </suppress>
-  
+
   <suppress>
     <notes><![CDATA[
         CVE is a json vulnerability for Node projects. False positive reported at https://github.com/jeremylong/DependencyCheck/issues/2794
@@ -17,10 +17,5 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
 	</suppress>
-
-  <suppress until="2021-11-25">
-    <notes>Temp suppression to unblock pipeline.</notes>
-    <cve>CVE-2021-22096</cve>
-  </suppress>
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2140 (https://tools.hmcts.net/jira/browse/CCD-2140)


### Change description ###
- Updated build.gradle.  Added override of spring-framework.version property with value set to 5.3.12 to address CVE-2021-22096.
- Removed temporary suppression of CVE-2021-22096 from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
