### PR TITLE
CCD-2374: Update log4j version to 2.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,7 @@ ext.libraries = [
 ]
 
 ext['spring-framework.version'] = '5.3.12'
-ext['log4j2.version'] = '2.16.0'
+ext['log4j2.version'] = '2.17.0'
 
 dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-2351

### Change description ###
Update log4j version to 2.17.0.
- Mitigations for CVE-2021-45105, CVE-2021-45046 and CVE-2021-44228

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```