### PR TITLE
CCD-2588 CVE fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,8 +188,8 @@ ext.libraries = [
   ]
 ]
 
-ext['spring-framework.version'] = '5.3.12'
-ext['log4j2.version'] = '2.17.0'
+ext['spring-framework.version'] = '5.3.15'
+ext['log4j2.version'] = '2.17.1'
 
 dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
@@ -206,8 +206,8 @@ dependencies {
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: versions.reformLogging
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.7.RELEASE'
 
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.54'
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.0.12'
+  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.58'
+  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.1.0-M10'
 
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   compile group: 'org.projectlombok', name: 'lombok', version: versions.lombok
@@ -217,6 +217,9 @@ dependencies {
 
   // CVE-2021-28170
   compile "org.glassfish:jakarta.el:4.0.1"
+  // CVE-2021-42550
+  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'
+  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.10'
 
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -16,14 +16,6 @@
     ]]></notes>
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
-	</suppress>
-
-  <suppress until="2022-02-25">
-    <notes><![CDATA[Temporary suppression pending investigation]]></notes>
-    <cve>CVE-2021-22060</cve>
-    <cve>CVE-2022-23181</cve>
-    <cve>CVE-2021-42550</cve>
-    <cve>CVE-2021-44832</cve>
   </suppress>
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ccd-2588
https://tools.hmcts.net/jira/browse/ccd-2614
https://tools.hmcts.net/jira/browse/ccd-2640
https://tools.hmcts.net/jira/browse/CCD-2627

### Change description ###
Fixing:
- CVE-2021-22060
- CVE-2022-23181
- CVE-2021-42550
- CVE-2021-44832

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```